### PR TITLE
Fix: position demo opacity reset back to 1 & "pos_info" text

### DIFF
--- a/DearPyGui_Animate/dearpygui_animate_demo.py
+++ b/DearPyGui_Animate/dearpygui_animate_demo.py
@@ -89,7 +89,7 @@ def demo_position(sender, data):
 	animate.add("position", "Position Demo", [500,300], [500,0], [.51,.05,.5,.9], 300, timeoffset=11, early_callback=update_demo_position_text)
 	animate.add("position", "Position Demo", [500,300], [500,600], [.51,.05,.5,.9], 300, timeoffset=11)
 	
-	animate.add("opacity", "Position Demo", 1, 0, [.51,.05,.5,.9], 20, timeoffset=18, callback=remove_pos_demo)
+	animate.add("opacity", "Position Demo", 1, 1, [.51,.05,.5,.9], 20, timeoffset=18, callback=remove_pos_demo)
 	
 	
 def update_demo_position_text(sender, data):
@@ -98,6 +98,8 @@ def update_demo_position_text(sender, data):
 
 
 def remove_pos_demo(sender, data):
+	delete_item("pos_info")
+	add_text("pos_info", default_value="Animations can be stagged,\nindividual values will add up", parent="Position Demo", before="spacing")
 	hide_item("Position Demo")
 	animate.add("position", "Demo", [20,20], [562,225], [.51,.05,.5,.9], 40)
 	animate.add("size", "Demo", [156,80], [156,170], [.51,.05,.5,.9], 40)


### PR DESCRIPTION
position animation demo not working after running it once
when position animation demo is finished, opactiy is set to 0 by line 92
changed it to 1 so the element will be visible in next run

"pos_info" text change back to initial text when the demo ends