### PR TITLE
Upgrading to new versions of DearPyGui v1.X

### DIFF
--- a/DearPyGui_Animate/dearpygui_animate.py
+++ b/DearPyGui_Animate/dearpygui_animate.py
@@ -8,20 +8,15 @@ v0.11
 ----------------------------------------------
 """
 
-
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # 				Imports
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
-from dearpygui.core import *	# update this to latest DearPyGUI API
-from dearpygui.simple import *	# update this to latest DearPyGUI API
+import dearpygui.dearpygui as dpg
 
-
-
-
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # 				Global Registers
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 animations = []
 delta_positions = []
@@ -29,555 +24,573 @@ delta_sizes = []
 delta_opacities = []
 
 
-
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # 				Main Functions
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 def add(type, object, startval, endval, ease, duration, **kwargs):
-	"""
-	adds a new animation to animations register
-	"""
-	
-	# fix min-values: smallest size window = 32x32, smallest size item = 1x1
-	if type == "size":
-		if get_item_type(object) == "mvAppItemType::Window":
-			for i in range(2):
-				if startval[i] < 32:
-					startval[i] = 32
-					
-				elif endval[i] < 32:
-					endval[i] = 32
-		else:
-			for i in range(2):
-				if startval[i] < 1:
-					startval[i] = 1
-				
-				elif endval[i] < 1:
-					endval[i] = 1
+    """
+    adds a new animation to animations register
+    """
 
-	# rewrite endval to distance, all calculations are based on distance
-	try:
-		distance = [endval[0] - startval[0], endval[1] - startval[1]]
-	except:
-		distance = endval - startval
-		
-	options = {
-		"name" : "",
-		"timeoffset" : 0,
-		"loop": "",
-		"callback" : "",
-		"callback_data" : "",
-		"early_callback" : "",
-		"early_callback_data" : ""
-		}		
-	options.update(kwargs)
-	
-	starttime = get_total_time() + options["timeoffset"]
-	framecounter = 0
-	last_ease = 0
-	loopcounter = 0
-	isplaying = None
-	ispaused = False
-	isreversed = False
+    # fix min-values: smallest size window = 32x32, smallest size item = 1x1
+    if type == "size":
+        if dpg.get_item_type(object) == "mvAppItemType::Window":
+            for i in range(2):
+                if startval[i] < 32:
+                    startval[i] = 32
 
-	new_animation = [
-		options["name"],
-		type,
-		object,
-		startval,
-		distance,
-		ease,
-		duration,
-		starttime,
-		framecounter,
-		last_ease,
-		options["loop"],
-		loopcounter,
-		options["callback"],
-		options["callback_data"],
-		options["early_callback"],
-		options["early_callback_data"],
-		isplaying,
-		ispaused, 
-		isreversed
-		]
-	
-	global animations
-	animations.append(new_animation)
+                elif endval[i] < 32:
+                    endval[i] = 32
+        else:
+            for i in range(2):
+                if startval[i] < 1:
+                    startval[i] = 1
+
+                elif endval[i] < 1:
+                    endval[i] = 1
+
+    # rewrite endval to distance, all calculations are based on distance
+    try:
+        distance = [endval[0] - startval[0], endval[1] - startval[1]]
+    except Exception:
+        distance = endval - startval
+
+    options = {
+        "name": "",
+        "timeoffset": 0,
+        "loop": "",
+        "callback": "",
+        "callback_data": "",
+        "early_callback": "",
+        "early_callback_data": ""
+    }
+    options.update(kwargs)
+
+    starttime = dpg.get_total_time() + options["timeoffset"]
+    framecounter = 0
+    last_ease = 0
+    loopcounter = 0
+    isplaying = None
+    ispaused = False
+    isreversed = False
+
+    new_animation = [
+        options["name"],
+        type,
+        object,
+        startval,
+        distance,
+        ease,
+        duration,
+        starttime,
+        framecounter,
+        last_ease,
+        options["loop"],
+        loopcounter,
+        options["callback"],
+        options["callback_data"],
+        options["early_callback"],
+        options["early_callback_data"],
+        isplaying,
+        ispaused,
+        isreversed
+    ]
+
+    global animations
+    animations.append(new_animation)
 
 
 def run():
-	"""
-	Animation data-set layout:
+    """
+    Animation data-set layout:
 
-	animation[0] = animation name
-	animation[1] = animation type
-	animation[2] = object name
-	animation[3] = start value
-	animation[4] = distance
-	animation[5] = ease
-	animation[6] = duration
-	animation[7] = starttime
-	animation[8] = frame counter
-	animation[9] = last ease
-	animation[10] = loop
-	animation[11] = loop counter
-	animation[12] = callback function
-	animation[13] = function data
-	animation[14] = early callback
-	animation[15] = early callback data
-	animation[16] = isplaying
-	animation[17] = ispaused
-	animation[18] = isreversed
-	"""
+    animation[0] = animation name
+    animation[1] = animation type
+    animation[2] = object name
+    animation[3] = start value
+    animation[4] = distance
+    animation[5] = ease
+    animation[6] = duration
+    animation[7] = starttime
+    animation[8] = frame counter
+    animation[9] = last ease
+    animation[10] = loop
+    animation[11] = loop counter
+    animation[12] = callback function
+    animation[13] = function data
+    animation[14] = early callback
+    animation[15] = early callback data
+    animation[16] = isplaying
+    animation[17] = ispaused
+    animation[18] = isreversed
+    """
 
-	animations_updated = []
-	callbacks = {}
-	global animations
-	global generators
-					
-	for animation in animations:
-					
-		if get_total_time() >= animation[7] and not animation[17]:
-				
-			if animation[14] and animation[8] == 0:
-				callbacks[animation[14]] = (animation[2], animation[15])
-			
-			animation[16] = True
-			frame = animation[8] / animation[6]
-			ease = BezierTransistion(frame, animation[5])
-			
-			if animation[1] == "position":
-				add_delta_positions(animation, ease)
-			
-			elif animation[1] == "size":
-				add_delta_sizes(animation, ease)
+    animations_updated = []
+    callbacks = {}
+    global animations
+    global generators
 
-			elif animation[1] == "opacity":
-				add_delta_opacities(animation, ease)
-				
-			animation[9] = ease
-						
-			if animation[8] < animation[6]:
-				if not animation[18]:
-					animation[8] += 1
-				else:
-					if animation[8] == 0:
-						animation[18] = False
-						animation[8] = 1
-					else:
-						animation[8] -= 1
-				animations_updated.append(animation)
+    for animation in animations:
 
-			elif animation[8] == animation[6]:
-				if animation[10]:
-					set_loop(animation, animations_updated)
+        if dpg.get_total_time() >= animation[7] and not animation[17]:
 
-				if animation[12]:
-					callbacks[animation[12]] = (animation[2], animation[13])
+            if animation[14] and animation[8] == 0:
+                callbacks[animation[14]] = (animation[2], animation[15])
 
-		else:
-			animations_updated.append(animation)
+            animation[16] = True
+            frame = animation[8] / animation[6]
+            ease = BezierTransistion(frame, animation[5])
 
-	set_pos()
-	set_size()
-	set_opacity()
+            if animation[1] == "position":
+                add_delta_positions(animation, ease)
 
-	animations = animations_updated
+            elif animation[1] == "size":
+                add_delta_sizes(animation, ease)
 
-	for func, dat in callbacks.items():
-		func(dat[0], dat[1])
-		
+            elif animation[1] == "opacity":
+                add_delta_opacities(animation, ease)
+
+            animation[9] = ease
+
+            if animation[8] < animation[6]:
+                if not animation[18]:
+                    animation[8] += 1
+                else:
+                    if animation[8] == 0:
+                        animation[18] = False
+                        animation[8] = 1
+                    else:
+                        animation[8] -= 1
+                animations_updated.append(animation)
+
+            elif animation[8] == animation[6]:
+                if animation[10]:
+                    set_loop(animation, animations_updated)
+
+                if animation[12]:
+                    callbacks[animation[12]] = (animation[2], animation[13])
+
+        else:
+            animations_updated.append(animation)
+
+    set_pos()
+    set_size()
+    set_opacity()
+
+    animations = animations_updated
+
+    for func, dat in callbacks.items():
+        func(dat[0], dat[1])
+
 
 def play(animation_name):
-	"""
-	resumes an animation
-	"""
+    """
+    resumes an animation
+    """
 
-	global animations
-	
-	for animation in animations:
-		if animation[0] == animation_name:
-			animation[17] = False
+    global animations
+
+    for animation in animations:
+        if animation[0] == animation_name:
+            animation[17] = False
 
 
 def pause(animation_name):
-	"""
-	pauses an animation
-	"""
+    """
+    pauses an animation
+    """
 
-	global animations
-	
-	for animation in animations:
-		if animation[0] == animation_name:
-			animation[17] = True
+    global animations
+
+    for animation in animations:
+        if animation[0] == animation_name:
+            animation[17] = True
 
 
 def remove(animation_name):
-	"""
-	removes an animation from animations register
-	"""
-	
-	animations_updated = []
-	delta_positions_updated = []
-	delta_sizes_updated = []
-	delta_opacities_updated = []
-	object_anitype = []
-	global animations
-	global delta_positions
-	global delta_sizes
-	global delta_opacities
-	
-	for animation in animations:
-		if not animation[0] == animation_name:
-			animations_updated.append(animation)
-		else:
-			object_anitype = [animation[2], animation[1]]
-	
-	if object_anitype:
-		found = False
-		for ani in animations_updated:
-			if ani[2] == object_anitype[0] and ani[1] == object_anitype[1]:
-				found = True
-				break
-				
-		if not found:
-			if object_anitype[1] == "position":
-				for entry in delta_positions:
-					if not entry[0] == object_anitype[0]:
-						delta_positions_updated.append(entry)
-				delta_positions = delta_positions_updated
-			
-			elif object_anitype[1] == "size":
-				for entry in delta_sizes:
-					if not entry[0] == object_anitype[0]:
-						delta_sizes_updated.append(entry)
-				delta_sizes = delta_sizes_updated
+    """
+    removes an animation from animations register
+    """
 
-			elif object_anitype[1] == "opacity":
-				for entry in delta_opacities:
-					if not entry[0] == object_anitype[0]:
-						delta_opacities_updated.append(entry)
-				delta_opacities = delta_opacities_updated
+    animations_updated = []
+    delta_positions_updated = []
+    delta_sizes_updated = []
+    delta_opacities_updated = []
+    object_anitype = []
+    global animations
+    global delta_positions
+    global delta_sizes
+    global delta_opacities
 
-	animations = animations_updated
-	
+    for animation in animations:
+        if not animation[0] == animation_name:
+            animations_updated.append(animation)
+        else:
+            object_anitype = [animation[2], animation[1]]
+
+    if object_anitype:
+        found = False
+        for ani in animations_updated:
+            if ani[2] == object_anitype[0] and ani[1] == object_anitype[1]:
+                found = True
+                break
+
+        if not found:
+            if object_anitype[1] == "position":
+                for entry in delta_positions:
+                    if not entry[0] == object_anitype[0]:
+                        delta_positions_updated.append(entry)
+                delta_positions = delta_positions_updated
+
+            elif object_anitype[1] == "size":
+                for entry in delta_sizes:
+                    if not entry[0] == object_anitype[0]:
+                        delta_sizes_updated.append(entry)
+                delta_sizes = delta_sizes_updated
+
+            elif object_anitype[1] == "opacity":
+                for entry in delta_opacities:
+                    if not entry[0] == object_anitype[0]:
+                        delta_opacities_updated.append(entry)
+                delta_opacities = delta_opacities_updated
+
+    animations = animations_updated
+
+
 def get(*args):
-	"""
-	return animation data as requested
-	"""
+    """
+    return animation data as requested
+    """
 
-	return_data = []
-	global animations
-	
-	for animation in animations:
-		for entry in args:
-			if entry == "name":
-				return_data.append(animation[0])
-			
-			if entry == "type":
-				return_data.append(animation[1])
-			
-			if entry == "object":
-				return_data.append(animation[2])
+    return_data = []
+    global animations
 
-			if entry == "startval":
-				return_data.append(animation[3])
-				
-			if entry == "endval":
-				try:
-					endval = [animation[3][0] + animation[4][0], animation[3][1] + animation[4][1]]
-				except:
-					endval = animation[3] + animation[4]
-				return_data.append(endval)
-				
-			if entry == "ease":
-				return_data.append(animation[5])	
-				
-			if entry == "duration":
-				return_data.append(animation[6])
-			
-			if entry == "starttime":
-				return_data.append(animation[7])
-				
-			if entry == "framecounter":
-				return_data.append(animation[8])
-				
-			if entry == "loop":
-				return_data.append(animation[10])
-			
-			if entry == "loopcounter":
-				return_data.append(animation[11])
-				
-			if entry == "callback":
-				return_data.append(animation[12])
-				
-			if entry == "callback_data":
-				return_data.append(animation[13])
-				
-			if entry == "early_callback":
-				return_data.append(animation[14])
-				
-			if entry == "early_callback_data":
-				return_data.append(animation[15])
-				
-			if entry == "isplaying":
-				return_data.append(animation[16])
-				
-			if entry == "ispaused":
-				return_data.append(animation[17])
-	
-	if not return_data:
-		return False
-	
-	else:
-		return return_data
+    for animation in animations:
+        for entry in args:
+            if entry == "name":
+                return_data.append(animation[0])
+
+            if entry == "type":
+                return_data.append(animation[1])
+
+            if entry == "object":
+                return_data.append(animation[2])
+
+            if entry == "startval":
+                return_data.append(animation[3])
+
+            if entry == "endval":
+                try:
+                    endval = [animation[3][0] + animation[4][0], animation[3][1] + animation[4][1]]
+                except Exception:
+                    endval = animation[3] + animation[4]
+                return_data.append(endval)
+
+            if entry == "ease":
+                return_data.append(animation[5])
+
+            if entry == "duration":
+                return_data.append(animation[6])
+
+            if entry == "starttime":
+                return_data.append(animation[7])
+
+            if entry == "framecounter":
+                return_data.append(animation[8])
+
+            if entry == "loop":
+                return_data.append(animation[10])
+
+            if entry == "loopcounter":
+                return_data.append(animation[11])
+
+            if entry == "callback":
+                return_data.append(animation[12])
+
+            if entry == "callback_data":
+                return_data.append(animation[13])
+
+            if entry == "early_callback":
+                return_data.append(animation[14])
+
+            if entry == "early_callback_data":
+                return_data.append(animation[15])
+
+            if entry == "isplaying":
+                return_data.append(animation[16])
+
+            if entry == "ispaused":
+                return_data.append(animation[17])
+
+    if not return_data:
+        return False
+
+    else:
+        return return_data
 
 
-
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # 				Helper Functions
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
-def BezierTransistion (search, handles):
-	"""
-	solving y (progress) of bezier curve for given x (time)
-	using the newton-raphson method
-	"""
+def BezierTransistion(search, handles):
+    """
+    solving y (progress) of bezier curve for given x (time)
+    using the newton-raphson method
+    """
 
-	h1x, h1y, h2x, h2y = handles
-	
-	cx = 3 * h1x
-	bx = 3 * (h2x - h1x) - cx
-	ax = 1 - cx - bx
-	
-	t = search
+    h1x, h1y, h2x, h2y = handles
 
-	for i in range (100):
-		x = (ax*t**3 + bx*t**2 + cx*t) - search
-				
-		if round(x,4) == 0:
-			break
-		
-		dx = 3.0 * ax*t**2 + 2.0 * bx * t + cx
-		
-		t -= (x/dx)		
-		
-	return 3*t*(1-t)**2 *h1y + 3*t**2 *(1-t) *h2y + t**3
+    cx = 3 * h1x
+    bx = 3 * (h2x - h1x) - cx
+    ax = 1 - cx - bx
+
+    t = search
+
+    for i in range(100):
+        x = (ax * t ** 3 + bx * t ** 2 + cx * t) - search
+
+        if round(x, 4) == 0:
+            break
+
+        dx = 3.0 * ax * t ** 2 + 2.0 * bx * t + cx
+
+        t -= (x / dx)
+
+    return 3 * t * (1 - t) ** 2 * h1y + 3 * t ** 2 * (1 - t) * h2y + t ** 3
 
 
 def set_loop(animation, animations_updated):
-	"""
-	prepare animation for next loop iteration
-	"""
-	
-	if animation[10] == "ping-pong":	
-		animation[18] = True
-		animation[8] -= 1
-		animation[9] = 1
-			
-	elif animation[10] == "cycle":
-		animation[8] = 0
-		animation[9] = 0
-		
+    """
+    prepare animation for next loop iteration
+    """
 
-		
-	elif animation[10] == "continue":
-		try:
-			animation[3] = [animation[3][0] + animation[4][0], animation[3][1] + animation[4][1]]
-		except:
-			animation[3] += animation[4]
-		animation[8] = 0
-		animation[9] = 0
+    if animation[10] == "ping-pong":
+        animation[18] = True
+        animation[8] -= 1
+        animation[9] = 1
 
-	animation[11] += 1
-	animations_updated.append(animation)
+    elif animation[10] == "cycle":
+        animation[8] = 0
+        animation[9] = 0
+
+    elif animation[10] == "continue":
+        try:
+            animation[3] = [animation[3][0] + animation[4][0], animation[3][1] + animation[4][1]]
+        except Exception:
+            animation[3] += animation[4]
+        animation[8] = 0
+        animation[9] = 0
+
+    animation[11] += 1
+    animations_updated.append(animation)
 
 
-def add_delta_positions(animation, ease):	
-	"""
-	collects delta movements of all position animations for a certain item
-	"""
-		
-	global delta_positions
-			
-	for item in delta_positions:
-		if animation[2] == item[0]:
-					
-			x_step = animation[4][0] * (ease - animation[9])
-			y_step = animation[4][1] * (ease - animation[9])
-			
-			item[1] += x_step
-			item[2] += y_step
-			
-			if animation[8] < animation[6] or animation[10]:
-				item[3] = True
-			
-			if animation[10] == "cycle" and animation[8] == animation[6]:
-				item[3] = False
-				
-			if animation[8] == animation[6] and not item[3]:
-				item[3] = False
-				
-			break	
-	else:
-		delta_positions.append([animation[2], animation[3][0], animation[3][1], True])
+def add_delta_positions(animation, ease):
+    """
+    collects delta movements of all position animations for a certain item
+    """
+
+    global delta_positions
+
+    for item in delta_positions:
+        if animation[2] == item[0]:
+
+            x_step = animation[4][0] * (ease - animation[9])
+            y_step = animation[4][1] * (ease - animation[9])
+
+            item[1] += x_step
+            item[2] += y_step
+
+            if animation[8] < animation[6] or animation[10]:
+                item[3] = True
+
+            if animation[10] == "cycle" and animation[8] == animation[6]:
+                item[3] = False
+
+            if animation[8] == animation[6] and not item[3]:
+                item[3] = False
+
+            break
+    else:
+        delta_positions.append([animation[2], animation[3][0], animation[3][1], True])
 
 
 def add_delta_sizes(animation, ease):
-	"""
-	collects delta movements of all size animations for a certain item
-	"""
-	
-	global delta_sizes
-		
-	for item in delta_sizes:
-		if animation[2] == item[0]:
-			w_step = animation[4][0] * (ease - animation[9])
-			h_step = animation[4][1] * (ease - animation[9])
-			
-			item[1] += w_step
-			item[2] += h_step
-						
-			if animation[8] < animation[6] or animation[10]:
-				item[3] = True
-			
-			if animation[10] == "cycle" and animation[8] == animation[6]:
-				item[3] = False
-				
-			if animation[8] == animation[6] and not item[3]:
-				item[3] = False
-			
-			break
-	else:
-		delta_sizes.append([animation[2], animation[3][0], animation[3][1], True])
+    """
+    collects delta movements of all size animations for a certain item
+    """
+
+    global delta_sizes
+
+    for item in delta_sizes:
+        if animation[2] == item[0]:
+            w_step = animation[4][0] * (ease - animation[9])
+            h_step = animation[4][1] * (ease - animation[9])
+
+            item[1] += w_step
+            item[2] += h_step
+
+            if animation[8] < animation[6] or animation[10]:
+                item[3] = True
+
+            if animation[10] == "cycle" and animation[8] == animation[6]:
+                item[3] = False
+
+            if animation[8] == animation[6] and not item[3]:
+                item[3] = False
+
+            break
+    else:
+        delta_sizes.append([animation[2], animation[3][0], animation[3][1], True])
 
 
 def add_delta_opacities(animation, ease):
-	"""
-	collects delta movements of all opacity animations for a certain item
-	"""
-	
-	global delta_opacities
-						
-	for item in delta_opacities:
-		if animation[2] == item[0]:
-			o_step = animation[4] * (ease - animation[9])
-			
-			item[1] += o_step
-			
-			if animation[8] < animation[6] or animation[10]:
-				item[2] = True
-			
-			if animation[10] == "cycle" and animation[8] == animation[6]:
-				item[2] = False
-				
-			if animation[8] == animation[6] and not item[2]:
-				item[2] = False
-						
-			break
-	else:
-		delta_opacities.append([animation[2], animation[3], True])
+    """
+    collects delta movements of all opacity animations for a certain item
+    """
+
+    global delta_opacities
+
+    for item in delta_opacities:
+        if animation[2] == item[0]:
+            o_step = animation[4] * (ease - animation[9])
+
+            item[1] += o_step
+
+            if animation[8] < animation[6] or animation[10]:
+                item[2] = True
+
+            if animation[10] == "cycle" and animation[8] == animation[6]:
+                item[2] = False
+
+            if animation[8] == animation[6] and not item[2]:
+                item[2] = False
+
+            break
+    else:
+        delta_opacities.append([animation[2], animation[3], True])
 
 
 def set_pos():
-	"""
-	moves the item
-	"""
-	
-	global delta_positions
-		
-	items_updated = []
+    """
+    moves the item
+    """
 
-	for item in delta_positions:
-		if item[3] == None:
-			items_updated.append(item)
-			continue
-				
-		elif item[3]:
-			x_int = int(item[1])
-			y_int = int(item[2])
-			
-			item[3] = None
+    global delta_positions
 
-			items_updated.append(item)
-			
-		else:
-			x_int = round(item[1])
-			y_int = round(item[2])
-						
-		set_window_pos(item[0], x_int, y_int)	# update this to latest DearPyGUI API
+    items_updated = []
 
-	delta_positions = items_updated
-		
+    for item in delta_positions:
+        if item[3] is None:
+            items_updated.append(item)
+            continue
+
+        elif item[3]:
+            x_int = int(item[1])
+            y_int = int(item[2])
+
+            item[3] = None
+
+            items_updated.append(item)
+
+        else:
+            x_int = round(item[1])
+            y_int = round(item[2])
+
+        dpg.set_item_pos(item[0], [x_int, y_int])
+
+    delta_positions = items_updated
 
 
 def set_size():
-	"""
-	set items size
-	"""
-	
-	global delta_sizes
-		
-	items_updated = []
+    """
+    set items size
+    """
 
-	for item in delta_sizes:
-		if item[3] == None:
-			items_updated.append(item)
-			continue
+    global delta_sizes
 
-		elif item[3]:
-			w_int = int(item[1])
-			h_int = int(item[2])
-			
-			item[3] = None
+    items_updated = []
 
-			items_updated.append(item)
+    for item in delta_sizes:
+        if item[3] is None:
+            items_updated.append(item)
+            continue
 
-		else:
-			w_int = round(item[1])
-			h_int = round(item[2])
-			
-		set_item_width(item[0], w_int)		# update this to latest DearPyGUI API
-		set_item_height(item[0], h_int)		# update this to latest DearPyGUI API
+        elif item[3]:
+            w_int = int(item[1])
+            h_int = int(item[2])
 
-	delta_sizes = items_updated
+            item[3] = None
+
+            items_updated.append(item)
+
+        else:
+            w_int = round(item[1])
+            h_int = round(item[2])
+
+        dpg.set_item_width(item[0], w_int)
+        dpg.set_item_height(item[0], h_int)
+
+    delta_sizes = items_updated
+
+
+def dpg_get_alpha_style(item):
+    theme = dpg.get_item_theme(item)
+    if theme is None:
+        theme = dpg.add_theme()
+        theme_component = dpg.add_theme_component(dpg.mvAll, parent=theme)
+        alpha_style = dpg.add_theme_style(dpg.mvStyleVar_Alpha, 1, category=dpg.mvThemeCat_Core, parent=theme_component)
+        dpg.bind_item_theme(item, theme)
+        return alpha_style
+
+    all_components = dpg.get_item_children(theme, 1)
+    theme_component = None
+    for component in all_components:
+        if dpg.get_item_configuration(component)['item_type'] == dpg.mvAll:
+            theme_component = component
+            break
+    if theme_component is None:
+        theme_component = dpg.add_theme_component(parent=theme)
+
+    all_styles = dpg.get_item_children(theme_component, 1)
+    alpha_style = None
+    for style in all_styles:
+        if dpg.get_item_configuration(style)['target'] == dpg.mvStyleVar_Alpha:
+            alpha_style = style
+            break
+    if alpha_style is None:
+        alpha_style = dpg.add_theme_style(dpg.mvStyleVar_Alpha, 1, category=dpg.mvThemeCat_Core, parent=theme_component)
+    return alpha_style
 
 
 def set_opacity():
-	"""
-	set items opacity
-	"""
-	
-	global delta_opacities
-		
-	items_updated = []
+    """
+    set items opacity
+    """
 
-	for item in delta_opacities:
-		if item[2] == None:
-			items_updated.append(item)
-			continue
-			
-		elif item[2]:
-			item[2] = None
-			items_updated.append(item)
-		
-		# update this part to latest DearPyGUI API
-		if get_item_type(item[0]) == "mvAppItemType::Text":
-			new_color = get_item_configuration(item[0])["color"]
-			
-			# react to a bug in DearPyGui style system - review this when 0.7 is out
-			if new_color[0] > 255:
-				new_color = [255,255,255,255]
-				
-			new_color[3] = item[1]*255
-			configure_item(item[0], color = new_color)
-					
-		else:
-			set_item_style_var(item[0], mvGuiStyleVar_Alpha, [item[1]])
+    global delta_opacities
 
-			
-				
+    items_updated = []
 
-	delta_opacities = items_updated
+    for item in delta_opacities:
+        if item[2] is None:
+            items_updated.append(item)
+            continue
+
+        elif item[2]:
+            item[2] = None
+            items_updated.append(item)
+
+        if dpg.get_item_type(item[0]) == "mvAppItemType::mvText":
+            new_color = dpg.get_item_configuration(item[0])["color"]
+            new_color = list(map(lambda color: int(color * 255), new_color[:3:]))
+
+            new_color.append(item[1] * 255)
+
+            dpg.configure_item(item[0], color=new_color)
+        else:
+            dpg.set_value(dpg_get_alpha_style(item[0]), [item[1]])
+
+    delta_opacities = items_updated

--- a/DearPyGui_Animate/dearpygui_animate_demo.py
+++ b/DearPyGui_Animate/dearpygui_animate_demo.py
@@ -5,324 +5,372 @@ https://github.com/mrtnRitter/DearPyGui_Animate
 
 """
 
-from dearpygui.core import *
-from dearpygui.simple import *
+import dearpygui.dearpygui as dpg
+
 import dearpygui_animate as animate
 
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # 				Render Callback
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
-def onUpdate(sender, data):
-	"""
-	render callback function
-	"""
-	animate.run()
-	update_running_animations()
-	
+
+def onUpdate():
+    """
+    render callback function
+    """
+    animate.run()
+    update_running_animations()
 
 
 def update_running_animations():
-	playing = animate.get("isplaying")
-	
-	if playing:
-		running = 0
-		
-		for play in playing:
-			if play:
-				running += 1
-				
-		set_value("running_animations", "animations running: " + str(running))
-	
-	else:
-		set_value("running_animations", "animations running: 0")	
+    playing = animate.get("isplaying")
+
+    if playing:
+        running = 0
+
+        for play in playing:
+            if play:
+                running += 1
+
+        dpg.set_value("running_animations", "animations running: " + str(running))
+
+    else:
+        dpg.set_value("running_animations", "animations running: 0")
 
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # 				Main Menu Related
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 def show_buttons(sender, data):
-	# shorthand to unhide items before running animation
-	animate.add("opacity", "Info", 0, 1, [.64,.12,.72,.86], 20, timeoffset=10/60)
-	animate.add("opacity", "Animate Position", 0, 1, [.64,.12,.72,.86], 20, timeoffset=15/60, early_callback=lambda sender, data: show_item("Animate Position"))
-	animate.add("opacity", "Animate Size", 0, 1, [.64,.12,.72,.86], 20, timeoffset=20/60, early_callback=lambda sender, data: show_item("Animate Size"))
-	animate.add("opacity", "Animate Opacity", 0, 1, [.64,.12,.72,.86], 20, timeoffset=25/60, early_callback=lambda sender, data: show_item("Animate Opacity"))
+    # shorthand to unhide items before running animation
+    animate.add("opacity", "Info", 0, 1, [.64, .12, .72, .86], 20, timeoffset=10 / 60)
+    animate.add("opacity", "Animate Position", 0, 1, [.64, .12, .72, .86], 20, timeoffset=15 / 60, early_callback=lambda sender, data: dpg.show_item("Animate Position"))
+    animate.add("opacity", "Animate Size", 0, 1, [.64, .12, .72, .86], 20, timeoffset=20 / 60, early_callback=lambda sender, data: dpg.show_item("Animate Size"))
+    animate.add("opacity", "Animate Opacity", 0, 1, [.64, .12, .72, .86], 20, timeoffset=25 / 60, early_callback=lambda sender, data: dpg.show_item("Animate Opacity"))
 
 
+def gotoDemo(data):
+    if data == "position":
+        call = demo_position
+    elif data == "size":
+        call = demo_size
+    elif data == "opacity":
+        call = demo_opacity
 
-def gotoDemo(sender, data):	
-	if data == "position":
-		call = demo_position
-	elif data == "size":
-		call = demo_size
-	elif data == "opacity":
-		call = demo_opacity
-		
-	animate.add("position", "Demo", [562,225], [20,20], [.51,.05,.5,.9], 40)
-	animate.add("size", "Demo", [156,170], [156,80], [.51,.05,.5,.9], 40)
-	animate.add("opacity", "Demo", 1, 0.5, [.51,.05,.5,.9], 40, callback=call)
+    animate.add("position", "Demo", [562, 225], [20, 20], [.51, .05, .5, .9], 40)
+    animate.add("size", "Demo", [156, 170], [156, 80], [.51, .05, .5, .9], 40)
+    animate.add("opacity", "Demo", 1, 0.5, [.51, .05, .5, .9], 40, callback=call)
 
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # 				Position Demo Related
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 def demo_position(sender, data):
-	
-	# default values
-	delete_item("pos_info")
-	add_text("pos_info", default_value="Animations can be stagged,\nindividual values will add up", parent="Position Demo", before="spacing")
-	set_window_pos("Position Demo", 1500, -100)
-	animate.add("opacity", "Position Demo", 0, 1, [.51,.05,.5,.9], 1)
-	show_item("Position Demo")
-	
+    # default values
+    dpg.delete_item("pos_info")
+    dpg.add_text(tag="pos_info", default_value="Animations can be stagged,\nindividual values will add up", parent="Position Demo", before="spacing")
+    dpg.set_item_pos("Position Demo", [1500, -100])
+    animate.add("opacity", "Position Demo", 0, 1, [.51, .05, .5, .9], 1)
+    dpg.show_item("Position Demo")
 
-	# animations overlapping in time adding up their values
-	animate.add("position", "Position Demo", [1280, -100], [200,-100], [.51,.05,.5,.9], 600)
-	animate.add("position", "Position Demo", [1280, -100], [1280,300], [.51,.05,.5,.9], 600)
-	animate.add("position", "Position Demo", [1280, -100], [1000,0], [.51,.05,.5,.9], 30)
-	animate.add("position", "Position Demo", [0,0], [50,50], [.51,.05,.5,.9], 100, timeoffset=4)
-	animate.add("position", "Position Demo", [0,0], [200,0], [.51,.05,.5,.9], 100, timeoffset=5)
-	animate.add("position", "Position Demo", [0,0], [0,200], [.51,.05,.5,.9], 100, timeoffset=6)
-	animate.add("position", "Position Demo", [0,0], [0,-200], [.51,.05,.5,.9], 100, timeoffset=7)
-	animate.add("position", "Position Demo", [0,0], [500,-300], [.51,.05,.5,.9], 60, timeoffset=9)
-	
-	animate.add("position", "Position Demo", [670,150], [500,300], [.51,.05,.5,.9], 10, timeoffset=10)
-	
-	# animations cancel each other out, because they are exactly the same but with different directions
-	animate.add("position", "Position Demo", [500,300], [500,0], [.51,.05,.5,.9], 300, timeoffset=11, early_callback=update_demo_position_text)
-	animate.add("position", "Position Demo", [500,300], [500,600], [.51,.05,.5,.9], 300, timeoffset=11)
-	
-	animate.add("opacity", "Position Demo", 1, 0, [.51,.05,.5,.9], 20, timeoffset=18, callback=remove_pos_demo)
-	
-	
+    # animations overlapping in time adding up their values
+    animate.add("position", "Position Demo", [1280, -100], [200, -100], [.51, .05, .5, .9], 600)
+    animate.add("position", "Position Demo", [1280, -100], [1280, 300], [.51, .05, .5, .9], 600)
+    animate.add("position", "Position Demo", [1280, -100], [1000, 0], [.51, .05, .5, .9], 30)
+    animate.add("position", "Position Demo", [0, 0], [50, 50], [.51, .05, .5, .9], 100, timeoffset=4)
+    animate.add("position", "Position Demo", [0, 0], [200, 0], [.51, .05, .5, .9], 100, timeoffset=5)
+    animate.add("position", "Position Demo", [0, 0], [0, 200], [.51, .05, .5, .9], 100, timeoffset=6)
+    animate.add("position", "Position Demo", [0, 0], [0, -200], [.51, .05, .5, .9], 100, timeoffset=7)
+    animate.add("position", "Position Demo", [0, 0], [500, -300], [.51, .05, .5, .9], 60, timeoffset=9)
+
+    animate.add("position", "Position Demo", [670, 150], [500, 300], [.51, .05, .5, .9], 10, timeoffset=10)
+
+    # animations cancel each other out, because they are exactly the same but with different directions
+    animate.add("position", "Position Demo", [500, 300], [500, 0], [.51, .05, .5, .9], 300, timeoffset=11, early_callback=update_demo_position_text)
+    animate.add("position", "Position Demo", [500, 300], [500, 600], [.51, .05, .5, .9], 300, timeoffset=11)
+
+    animate.add("opacity", "Position Demo", 1, 0, [.51, .05, .5, .9], 20, timeoffset=18, callback=remove_pos_demo)
+
+
 def update_demo_position_text(sender, data):
-	delete_item("pos_info")
-	add_text("pos_info", default_value="Now two animations are\npulling against each other\n... really!", parent="Position Demo", before="spacing")
+    dpg.delete_item("pos_info")
+    dpg.add_text(tag="pos_info", default_value="Now two animations are\npulling against each other\n... really!", parent="Position Demo", before="spacing")
 
 
 def remove_pos_demo(sender, data):
-	hide_item("Position Demo")
-	animate.add("position", "Demo", [20,20], [562,225], [.51,.05,.5,.9], 40)
-	animate.add("size", "Demo", [156,80], [156,170], [.51,.05,.5,.9], 40)
-	animate.add("opacity", "Demo", 0.5, 1, [.51,.05,.5,.9], 40)
+    dpg.hide_item("Position Demo")
+    animate.add("position", "Demo", [20, 20], [562, 225], [.51, .05, .5, .9], 40)
+    animate.add("size", "Demo", [156, 80], [156, 170], [.51, .05, .5, .9], 40)
+    animate.add("opacity", "Demo", 0.5, 1, [.51, .05, .5, .9], 40)
 
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # 				Size Demo Related
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 def demo_size(sender, data):
-	# default values
-	animate.add("opacity", "Size Demo", 1, 0, [.51,.05,.5,.9], 1)
-	animate.add("size", "Size Demo", [220,120], [220,120], [.51,.05,.5,.9], 1)
-	animate.add("position", "Size Demo", [530,260], [530,260], [.51,.05,.5,.9], 1)
-	animate.add("size", "continued", [204,20], [204,20], [.51,.05,.5,.9], 1)
-	animate.add("size", "paused", [204,20], [204,20], [.51,.05,.5,.9], 1)
-	animate.add("size", "terminated", [204,20], [204,20], [.51,.05,.5,.9], 1)
-	
-	animate.add("opacity", "Size Demo", 0, 1, [.51,.05,.5,.9], 60, timeoffset= 2/60, early_callback=lambda sender, data: show_item("Size Demo"))
-	
-	animate.add("size", "Size Demo", [220,120], [500,360], [.51,.05,.5,.9], 120, loop="ping-pong", name="size_loop")
-	animate.add("position", "Size Demo", [530, 260], [390, 70], [.51,.05,.5,.9], 120, loop="ping-pong", name="pos_loop")
-	animate.add("size", "continued", [204,20], [484,100], [.51,.05,.5,.9], 120, loop="ping-pong", name="size_loop_btn1")
-	animate.add("size", "paused", [204,20], [484,100], [.51,.05,.5,.9], 120, loop="ping-pong", name="size_loop_btn2")
-	animate.add("size", "terminated", [204,20], [484,100], [.51,.05,.5,.9], 120, loop="ping-pong", name="size_loop_btn3")
-		
-	animate.pause("size_loop")
-	animate.pause("pos_loop")
-	animate.pause("size_loop_btn1")
-	animate.pause("size_loop_btn2")
-	animate.pause("size_loop_btn3")
-	
+    # default values
+    animate.add("opacity", "Size Demo", 1, 0, [.51, .05, .5, .9], 1)
+    animate.add("size", "Size Demo", [220, 120], [220, 120], [.51, .05, .5, .9], 1)
+    animate.add("position", "Size Demo", [530, 260], [530, 260], [.51, .05, .5, .9], 1)
+    animate.add("size", "continued", [204, 20], [204, 20], [.51, .05, .5, .9], 1)
+    animate.add("size", "paused", [204, 20], [204, 20], [.51, .05, .5, .9], 1)
+    animate.add("size", "terminated", [204, 20], [204, 20], [.51, .05, .5, .9], 1)
 
-def cont (sender, data):
-	animate.play("size_loop")
-	animate.play("pos_loop")
-	animate.play("size_loop_btn1")
-	animate.play("size_loop_btn2")
-	animate.play("size_loop_btn3")	
+    animate.add("opacity", "Size Demo", 0, 1, [.51, .05, .5, .9], 60, timeoffset=2 / 60, early_callback=lambda sender, data: dpg.show_item("Size Demo"))
+
+    animate.add("size", "Size Demo", [220, 120], [500, 360], [.51, .05, .5, .9], 120, loop="ping-pong", name="size_loop")
+    animate.add("position", "Size Demo", [530, 260], [390, 70], [.51, .05, .5, .9], 120, loop="ping-pong", name="pos_loop")
+    animate.add("size", "continued", [204, 20], [484, 100], [.51, .05, .5, .9], 120, loop="ping-pong", name="size_loop_btn1")
+    animate.add("size", "paused", [204, 20], [484, 100], [.51, .05, .5, .9], 120, loop="ping-pong", name="size_loop_btn2")
+    animate.add("size", "terminated", [204, 20], [484, 100], [.51, .05, .5, .9], 120, loop="ping-pong", name="size_loop_btn3")
+
+    animate.pause("size_loop")
+    animate.pause("pos_loop")
+    animate.pause("size_loop_btn1")
+    animate.pause("size_loop_btn2")
+    animate.pause("size_loop_btn3")
 
 
-def pause (sender, data):
-	animate.pause("size_loop")
-	animate.pause("pos_loop")
-	animate.pause("size_loop_btn1")
-	animate.pause("size_loop_btn2")
-	animate.pause("size_loop_btn3")
-	
-	
-def remove (sender, data):
-	animate.remove("size_loop")
-	animate.remove("pos_loop")
-	animate.remove("size_loop_btn1")
-	animate.remove("size_loop_btn2")
-	animate.remove("size_loop_btn3")
+def cont(sender, data):
+    animate.play("size_loop")
+    animate.play("pos_loop")
+    animate.play("size_loop_btn1")
+    animate.play("size_loop_btn2")
+    animate.play("size_loop_btn3")
+
+
+def pause(sender, data):
+    animate.pause("size_loop")
+    animate.pause("pos_loop")
+    animate.pause("size_loop_btn1")
+    animate.pause("size_loop_btn2")
+    animate.pause("size_loop_btn3")
+
+
+def remove(sender, data):
+    animate.remove("size_loop")
+    animate.remove("pos_loop")
+    animate.remove("size_loop_btn1")
+    animate.remove("size_loop_btn2")
+    animate.remove("size_loop_btn3")
 
 
 def remove_size_demo(sender, data):
-	animate.remove("size_loop")
-	animate.remove("pos_loop")
-	animate.remove("size_loop_btn1")
-	animate.remove("size_loop_btn2")
-	animate.remove("size_loop_btn3")
-	hide_item("Size Demo")
-	animate.add("position", "Demo", [20,20], [562,225], [.51,.05,.5,.9], 40)
-	animate.add("size", "Demo", [156,80], [156,170], [.51,.05,.5,.9], 40)
-	animate.add("opacity", "Demo", 0.5, 1, [.51,.05,.5,.9], 40)
+    animate.remove("size_loop")
+    animate.remove("pos_loop")
+    animate.remove("size_loop_btn1")
+    animate.remove("size_loop_btn2")
+    animate.remove("size_loop_btn3")
+    dpg.hide_item("Size Demo")
+    animate.add("position", "Demo", [20, 20], [562, 225], [.51, .05, .5, .9], 40)
+    animate.add("size", "Demo", [156, 80], [156, 170], [.51, .05, .5, .9], 40)
+    animate.add("opacity", "Demo", 0.5, 1, [.51, .05, .5, .9], 40)
 
 
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # 				Opacity Demo Related
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 def demo_opacity(sender, data):
-	animate.add("opacity", "Opacity Demo1", 0, 1, [.51,.05,.5,.9], 60, timeoffset= 2/60, early_callback=lambda sender, data: show_item("Opacity Demo1"), loop="ping-pong", name="top1")
-	animate.add("opacity", "Opacity Demo2", 0, 1, [.51,.05,.5,.9], 60, timeoffset= 22/60, early_callback=lambda sender, data: show_item("Opacity Demo2"), loop="ping-pong", name="top2")
-	animate.add("opacity", "Opacity Demo3", 0, 1, [.51,.05,.5,.9], 60, timeoffset= 42/60, early_callback=lambda sender, data: show_item("Opacity Demo3"), loop="ping-pong", name="top3")
-	animate.add("opacity", "Opacity Demo4", 0, 1, [.51,.05,.5,.9], 60, timeoffset= 62/60, early_callback=lambda sender, data: show_item("Opacity Demo4"), loop="ping-pong", name="top4")
-	
-	animate.add("opacity", "Loop1", 0.4, 1, [.51,.05,.5,.9], 10, timeoffset= 122/60, loop="ping-pong", name ="pp_loop")
-	animate.add("position", "Loop1", [565,800], [565,300], [.51,.05,.5,.9], 30, timeoffset= 125/60, early_callback=lambda sender, data: show_item("Loop1"))
+    animate.add("opacity", "Opacity Demo1", 0, 1, [.51, .05, .5, .9], 60, timeoffset=2 / 60, early_callback=lambda sender, data: dpg.show_item("Opacity Demo1"), loop="ping-pong", name="top1")
+    animate.add("opacity", "Opacity Demo2", 0, 1, [.51, .05, .5, .9], 60, timeoffset=22 / 60, early_callback=lambda sender, data: dpg.show_item("Opacity Demo2"), loop="ping-pong", name="top2")
+    animate.add("opacity", "Opacity Demo3", 0, 1, [.51, .05, .5, .9], 60, timeoffset=42 / 60, early_callback=lambda sender, data: dpg.show_item("Opacity Demo3"), loop="ping-pong", name="top3")
+    animate.add("opacity", "Opacity Demo4", 0, 1, [.51, .05, .5, .9], 60, timeoffset=62 / 60, early_callback=lambda sender, data: dpg.show_item("Opacity Demo4"), loop="ping-pong", name="top4")
+
+    animate.add("opacity", "Loop1", 0.4, 1, [.51, .05, .5, .9], 10, timeoffset=122 / 60, loop="ping-pong", name="pp_loop")
+    animate.add("position", "Loop1", [565, 800], [565, 300], [.51, .05, .5, .9], 30, timeoffset=125 / 60, early_callback=lambda sender, data: dpg.show_item("Loop1"))
 
 
 def loop_cycle(sender, data):
-	animate.add("position", "Loop1", [565,300], [1500,300], [.51,.05,.5,.9], 30, callback=lambda sender, data: hide_item("Loop1"))
-	animate.remove("pp_loop")
-	
-	animate.add("opacity", "Loop2", 0, 1, [.51,.05,.5,.9], 30, timeoffset= 1, early_callback=lambda sender, data: show_item("Loop2"))
-	animate.add("size", "Loop2", [0,0], [180,110], [.06,.54,.11,.98], 85, timeoffset= 1, loop="cycle", name="cycleloop_size")
-	animate.add("position", "Loop2", [639,339], [565,300], [.06,.54,.11,.98], 85, timeoffset= 1, loop="cycle", name="cycleloop_pos")
-	
-	
-	
+    animate.add("position", "Loop1", [565, 300], [1500, 300], [.51, .05, .5, .9], 30, callback=lambda sender, data: dpg.hide_item("Loop1"))
+    animate.remove("pp_loop")
+
+    animate.add("opacity", "Loop2", 0, 1, [.51, .05, .5, .9], 30, timeoffset=1, early_callback=lambda sender, data: dpg.show_item("Loop2"))
+    animate.add("size", "Loop2", [0, 0], [180, 120], [.06, .54, .11, .98], 85, timeoffset=1, loop="cycle", name="cycleloop_size")
+    animate.add("position", "Loop2", [639, 339], [565, 300], [.06, .54, .11, .98], 85, timeoffset=1, loop="cycle", name="cycleloop_pos")
+
+
 def loop_continue(sender, data):
-	animate.remove("cycleloop_size")
-	animate.remove("cycleloop_pos")
-	
-	x,y = get_window_pos("Loop2")
-	animate.add("position", "Loop2", [x,y], [x, 800], [.06,.54,.11,.98], 20)
-	animate.add("opacity", "Loop2", 1,0, [.06,.54,.11,.98], 20, callback=lambda sender, data: hide_item("Loop2"))
-	
-	animate.add("position", "Loop3", [-300, 300], [-250,300], [.01,.97,.1,.98], 30, loop="continue", callback=checkforEnd, name="cont_loop")
-	show_item("Loop3")
-	
-	
+    animate.remove("cycleloop_size")
+    animate.remove("cycleloop_pos")
+
+    x, y = dpg.get_item_pos("Loop2")
+    animate.add("position", "Loop2", [x, y], [x, 800], [.06, .54, .11, .98], 20)
+    animate.add("opacity", "Loop2", 1, 0, [.06, .54, .11, .98], 20, callback=lambda sender, data: dpg.hide_item("Loop2"))
+
+    animate.add("position", "Loop3", [-300, 300], [-250, 300], [.01, .97, .1, .98], 30, loop="continue", callback=checkforEnd, name="cont_loop")
+    dpg.show_item("Loop3")
+
+
 def checkforEnd(sender, data):
-	x = get_window_pos("Loop3")[0]
-	
-	if x > 1200:
-		loop_close("Loop3", None)
+    x = dpg.get_item_pos("Loop3")[0]
+
+    if x > 1200:
+        loop_close("Loop3", None)
+
 
 def loop_close(sender, data):
-	animate.remove("cont_loop")
-	hide_item("Loop3")
-	
-	animate.remove("top1")
-	animate.remove("top2")
-	animate.remove("top3")
-	animate.remove("top4")
-	hide_item("Opacity Demo1")
-	hide_item("Opacity Demo2")
-	hide_item("Opacity Demo3")
-	hide_item("Opacity Demo4")
-	
-	animate.add("position", "Demo", [20,20], [562,225], [.51,.05,.5,.9], 40)
-	animate.add("size", "Demo", [156,80], [156,170], [.51,.05,.5,.9], 40)
-	animate.add("opacity", "Demo", 0.5, 1, [.51,.05,.5,.9], 40)
-	
-	
+    animate.remove("cont_loop")
+    dpg.hide_item("Loop3")
 
-#-----------------------------------------------------------------------------
+    animate.remove("top1")
+    animate.remove("top2")
+    animate.remove("top3")
+    animate.remove("top4")
+    dpg.hide_item("Opacity Demo1")
+    dpg.hide_item("Opacity Demo2")
+    dpg.hide_item("Opacity Demo3")
+    dpg.hide_item("Opacity Demo4")
+
+    animate.add("position", "Demo", [20, 20], [562, 225], [.51, .05, .5, .9], 40)
+    animate.add("size", "Demo", [156, 80], [156, 170], [.51, .05, .5, .9], 40)
+    animate.add("opacity", "Demo", 0.5, 1, [.51, .05, .5, .9], 40)
+
+
+# -----------------------------------------------------------------------------
 # 					Windows
-#-----------------------------------------------------------------------------	
+# -----------------------------------------------------------------------------
 
-with window("Main"):
-	set_main_window_title("dearpygui_animate    D E M O")
-	set_main_window_size(1280,720)
-	set_main_window_pos(960-640,600-360)
-	set_main_window_resizable(False)
-	set_theme("Dark Grey")
-	set_style_window_title_align(0.5,0.5)
+dpg.create_context()
+dpg.create_viewport(title="dearpygui_animate    D E M O", width=1280, height=720)
 
+with dpg.theme() as global_theme:
+    with dpg.theme_component(dpg.mvAll):
+        dpg.add_theme_style(dpg.mvStyleVar_WindowTitleAlign, 0.5, 0.5, category=dpg.mvThemeCat_Core)
+        dpg.add_theme_style(dpg.mvStyleVar_WindowRounding, 7, category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_Text, (255, 255, 255, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_TextDisabled, (128, 128, 128, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_WindowBg, (15, 15, 15, 240), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_ChildBg, (255, 255, 255, 0), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_PopupBg, (20, 20, 20, 240), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_Border, (110, 110, 128, 128), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_BorderShadow, (0, 0, 0, 0), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_FrameBg, (51, 54, 56, 138), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_FrameBgHovered, (102, 102, 102, 102), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_FrameBgActive, (46, 46, 46, 171), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_TitleBg, (10, 10, 10, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_TitleBgActive, (74, 74, 74, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_TitleBgCollapsed, (0, 0, 0, 130), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_MenuBarBg, (36, 36, 36, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_ScrollbarBg, (5, 5, 5, 135), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_ScrollbarGrab, (79, 79, 79, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_ScrollbarGrabHovered, (105, 105, 105, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_ScrollbarGrabActive, (130, 130, 130, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_CheckMark, (240, 240, 240, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_SliderGrab, (130, 130, 130, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_SliderGrabActive, (219, 219, 219, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_Button, (112, 112, 112, 102), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_ButtonHovered, (117, 120, 122, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_ButtonActive, (107, 107, 107, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_Header, (179, 179, 179, 79), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_HeaderHovered, (179, 179, 179, 204), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_HeaderActive, (122, 128, 133, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_Separator, (110, 110, 128, 128), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_SeparatorHovered, (184, 184, 184, 199), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_SeparatorActive, (130, 130, 130, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_ResizeGrip, (232, 232, 232, 64), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_ResizeGripHovered, (207, 207, 207, 171), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_ResizeGripActive, (117, 117, 117, 242), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_Tab, (46, 89, 148, 220), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_TabHovered, (66, 150, 250, 204), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_TabActive, (51, 105, 173, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_TabUnfocused, (17, 26, 38, 248), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_TabUnfocusedActive, (35, 67, 108, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_DockingPreview, (66, 150, 250, 179), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_DockingEmptyBg, (51, 51, 51, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_PlotLines, (156, 156, 156, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_PlotLinesHovered, (255, 110, 89, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_PlotHistogram, (186, 153, 38, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_PlotHistogramHovered, (255, 153, 0, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_TextSelectedBg, (222, 222, 222, 89), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_DragDropTarget, (255, 255, 0, 230), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_NavHighlight, (153, 153, 153, 255), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_NavWindowingHighlight, (255, 255, 255, 179), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_NavWindowingDimBg, (204, 204, 204, 51), category=dpg.mvThemeCat_Core)
+        dpg.add_theme_color(dpg.mvThemeCol_ModalWindowDimBg, (204, 204, 204, 89), category=dpg.mvThemeCat_Core)
 
-with window("Demo", width=36, height=32, no_resize=True, no_move=True, no_close=True, no_collapse=True, no_scrollbar=True):
-	add_text("Info", default_value="This demo will show \nsome basic functions\nof DearPyGui_Animate", parent="Demo", color=[255,255,255,0])
-	add_spacing(count=5, parent="Demo")
-	add_button("Animate Position", parent="Demo", width=140, callback=gotoDemo, callback_data="position")
-	add_button("Animate Size", parent="Demo", width=140, callback=gotoDemo, callback_data="size")
-	add_button("Animate Opacity", parent="Demo", width=140, callback=gotoDemo, callback_data="opacity")
-	hide_item("Animate Position")
-	hide_item("Animate Size")
-	hide_item("Animate Opacity")
-	
-with window("Position Demo", width = 220, height = 100, no_resize=True, no_move=True, no_close=True, no_collapse=True, no_scrollbar=True):
-	add_text("pos_info", default_value="Animations can be stagged,\nindividual values will add up")
-	add_spacing(count=3, name="spacing")
-	add_text("position status", source="running_animations")
-	hide_item("Position Demo")
+dpg.bind_theme(global_theme)
 
-with window("Size Demo", width = 220, height = 120, x_pos = 530, y_pos = 260, no_resize=True, no_move=True, no_collapse=True, no_scrollbar=True, on_close=remove_size_demo):
-	add_text("size_info", default_value="At any time animations can be")
-	add_button("continued", width=204, callback=cont)
-	add_button("paused", width=204, callback=pause)
-	add_button("terminated", width=204, callback=remove)
-	hide_item("Size Demo")
+with dpg.window(label="Demo", tag="Demo", width=36, height=32, min_size=[36, 32], no_resize=True, no_move=True, no_close=True, no_collapse=True, no_scrollbar=True):
+    dpg.add_text("This demo will show \nsome basic functions\nof DearPyGui_Animate", tag="Info", parent="Demo", color=[255, 255, 255, 0])
+    dpg.add_spacing(count=5, parent="Demo")
+    dpg.add_button(tag="Animate Position", label="Animate Position", parent="Demo", width=140, callback=lambda: gotoDemo("position"))
+    dpg.add_button(tag="Animate Size", label="Animate Size", parent="Demo", width=140, callback=lambda: gotoDemo("size"))
+    dpg.add_button(tag="Animate Opacity", label="Animate Opacity", parent="Demo", width=140, callback=lambda: gotoDemo("opacity"))
+    dpg.hide_item("Animate Position")
+    dpg.hide_item("Animate Size")
+    dpg.hide_item("Animate Opacity")
 
-with window("Opacity Demo1", width = 150, height = 80, x_pos = 300, y_pos = 100, no_resize=True, no_move=True, no_collapse=True, no_scrollbar=True, no_close=True, no_title_bar=True):
-	add_spacing(count=6, name="1")
-	add_text("op_info_1", default_value="    Animations")
-	hide_item("Opacity Demo1")
-	
-with window("Opacity Demo2", width = 150, height = 80, x_pos = 500, y_pos = 100, no_resize=True, no_move=True, no_collapse=True, no_scrollbar=True, no_close=True, no_title_bar=True):
-	add_spacing(count=6, name="2")
-	add_text("op_info_2", default_value="        can")
-	hide_item("Opacity Demo2")
-	
-with window("Opacity Demo3", width = 150, height = 80, x_pos = 700, y_pos = 100, no_resize=True, no_move=True, no_collapse=True, no_scrollbar=True, no_close=True, no_title_bar=True):
-	add_spacing(count=6, name="3")
-	add_text("op_info_3", default_value="        be")
-	hide_item("Opacity Demo3")
-	
-with window("Opacity Demo4", width = 150, height = 80, x_pos = 900, y_pos = 100, no_resize=True, no_move=True, no_collapse=True, no_scrollbar=True, no_close=True, no_title_bar=True):
-	add_spacing(count=6, name="4")
-	add_text("op_info_4", default_value="      looped")
-	hide_item("Opacity Demo4")
+with dpg.window(label="Position Demo", tag="Position Demo", width=220, height=110, no_resize=True, no_move=True, no_close=True, no_collapse=True, no_scrollbar=True):
+    dpg.add_text(tag="pos_info", default_value="Animations can be stagged,\nindividual values will add up")
+    with dpg.group(tag="spacing"):
+        dpg.add_spacing(count=3)
+    dpg.add_text("", tag="running_animations")
+    dpg.hide_item("Position Demo")
 
-with window("Loop1", width = 180, height = 110, x_pos = 565, y_pos = 300, no_resize=True, no_move=True, no_collapse=True, no_scrollbar=True, no_close=True, no_title_bar=True):
-	add_text("loop_info_1", default_value="       ping-pong")
-	add_text("loop_des_1", default_value="Moves from start to end,\nmoves back to start,\nrepeat")
-	add_spacing(count=3, name="5")
-	add_button("next_loop_1", width=164,label="next", callback=loop_cycle)
-	hide_item("Loop1")
+with dpg.window(label="Size Demo", tag="Size Demo", width=220, height=120, pos=[530, 260], no_resize=True, no_move=True, no_collapse=True, no_scrollbar=True, on_close=remove_size_demo):
+    dpg.add_text("At any time animations can be", tag="size_info")
+    dpg.add_button(label="continued", tag="continued", width=204, callback=cont)
+    dpg.add_button(label="paused", tag="paused", width=204, callback=pause)
+    dpg.add_button(label="terminated", tag="terminated", width=204, callback=remove)
+    dpg.hide_item("Size Demo")
 
-with window("Loop2", width = 180, height = 110, x_pos = 565, y_pos = 300, no_resize=True, no_move=True, no_collapse=True, no_scrollbar=True, no_close=True, no_title_bar=True):
-	add_text("loop_info_2", default_value="         cycle")
-	add_text("loop_des_2", default_value="Moves from start to end,\nrepeat\n")
-	add_spacing(count=7, name="6")
-	add_button("next_loop_2", width=164,label="next", callback=loop_continue)
-	hide_item("Loop2")
-	
-with window("Loop3", width = 180, height = 110, x_pos = 565, y_pos = 300, no_resize=True, no_move=True, no_collapse=True, no_scrollbar=True, no_close=True, no_title_bar=True):
-	add_text("loop_info_3", default_value="        continue")
-	add_text("loop_des_3", default_value="Moves from start to end\ntakes end as start\nrepeats movement")
-	add_spacing(count=3, name="7")
-	add_button("next_loop_3", width=164,label="close", callback=loop_close)
-	hide_item("Loop3")
+with dpg.window(tag="Opacity Demo1", width=150, height=80, min_size=[150, 80], pos=[300, 100], no_resize=True, no_move=True, no_collapse=True, no_scrollbar=True, no_close=True, no_title_bar=True):
+    dpg.add_spacing(count=6)
+    dpg.add_text(tag="op_info_1", default_value="    Animations")
+    dpg.hide_item("Opacity Demo1")
 
+with dpg.window(tag="Opacity Demo2", width=150, height=80, min_size=[150, 80], pos=[500, 100], no_resize=True, no_move=True, no_collapse=True, no_scrollbar=True, no_close=True, no_title_bar=True):
+    dpg.add_spacing(count=6)
+    dpg.add_text(tag="op_info_2", default_value="        can")
+    dpg.hide_item("Opacity Demo2")
 
+with dpg.window(tag="Opacity Demo3", width=150, height=80, min_size=[150, 80], pos=[700, 100], no_resize=True, no_move=True, no_collapse=True, no_scrollbar=True, no_close=True, no_title_bar=True):
+    dpg.add_spacing(count=6)
+    dpg.add_text(tag="op_info_3", default_value="        be")
+    dpg.hide_item("Opacity Demo3")
+
+with dpg.window(tag="Opacity Demo4", width=150, height=80, min_size=[150, 80], pos=[900, 100], no_resize=True, no_move=True, no_collapse=True, no_scrollbar=True, no_close=True, no_title_bar=True):
+    dpg.add_spacing(count=6)
+    dpg.add_text(tag="op_info_4", default_value="      looped")
+    dpg.hide_item("Opacity Demo4")
+
+with dpg.window(tag="Loop1", width=180, height=120, pos=[565, 300], no_resize=True, no_move=True, no_collapse=True, no_scrollbar=True, no_close=True, no_title_bar=True):
+    dpg.add_text(tag="loop_info_1", default_value="       ping-pong")
+    dpg.add_text(tag="loop_des_1", default_value="Moves from start to end,\nmoves back to start,\nrepeat")
+    dpg.add_spacing(count=3)
+    dpg.add_button(tag="next_loop_1", width=164, label="next", callback=loop_cycle)
+    dpg.hide_item("Loop1")
+
+with dpg.window(tag="Loop2", width=180, height=110, pos=[565, 300], no_resize=True, no_move=True, no_collapse=True, no_scrollbar=True, no_close=True, no_title_bar=True):
+    dpg.add_text(tag="loop_info_2", default_value="         cycle")
+    dpg.add_text(tag="loop_des_2", default_value="Moves from start to end,\nrepeat\n")
+    dpg.add_spacing(count=7)
+    dpg.add_button(tag="next_loop_2", width=164, label="next", callback=loop_continue)
+    dpg.hide_item("Loop2")
+
+with dpg.window(tag="Loop3", width=180, height=120, pos=[565, 300], no_resize=True, no_move=True, no_collapse=True, no_scrollbar=True, no_close=True, no_title_bar=True):
+    dpg.add_text(tag="loop_info_3", default_value="        continue")
+    dpg.add_text(tag="loop_des_3", default_value="Moves from start to end\ntakes end as start\nrepeats movement")
+    dpg.add_spacing(count=3)
+    dpg.add_button(tag="next_loop_3", width=164, label="close", callback=loop_close)
+    dpg.hide_item("Loop3")
 
 # Start Animation
-animate.add("position", "Demo", [622,800], [622, 304], [0,.06,.2,.99], 60)
-animate.add("opacity", "Demo", 0, 1, [.57,.06,.61,.86], 60)
-animate.add("size", "Demo", [36,32], [156,32], [0,.99,.47,1], 30, timeoffset=1.5, callback=show_buttons)
-animate.add("size", "Demo", [156,32], [156,170], [0,.65,.59,.92], 30, timeoffset=2)
-animate.add("position", "Demo", [622, 304], [562, 304], [0,.99,.47,1], 30, timeoffset=1.5)
-animate.add("position", "Demo", [562, 304], [562, 225], [0,.65,.59,.92], 30, timeoffset=2)
+animate.add("position", "Demo", [622, 800], [622, 304], [0, .06, .2, .99], 60)
+animate.add("opacity", "Demo", 0, 1, [.57, .06, .61, .86], 60)
+animate.add("size", "Demo", [36, 32], [156, 32], [0, .99, .47, 1], 30, timeoffset=1.5, callback=show_buttons)
+animate.add("size", "Demo", [156, 32], [156, 170], [0, .65, .59, .92], 30, timeoffset=2)
+animate.add("position", "Demo", [622, 304], [562, 304], [0, .99, .47, 1], 30, timeoffset=1.5)
+animate.add("position", "Demo", [562, 304], [562, 225], [0, .65, .59, .92], 30, timeoffset=2)
 
-
-add_value("running_animations", "0")
-set_render_callback(onUpdate)
-start_dearpygui(primary_window="Main")
+dpg.setup_dearpygui()
+dpg.show_viewport()
+while dpg.is_dearpygui_running():
+    onUpdate()
+    dpg.render_dearpygui_frame()
+dpg.destroy_context()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 **DearPyGui_Animate** is an add-on written on top of [DearPyGUI](https://github.com/hoffstadt/DearPyGui) to make UI animations possible.
 
-Tested for DearPyGui 0.6x
+Tested for DearPyGui 1.x
 
 <img src="https://raw.githubusercontent.com/mrtnRitter/DearPyGui_Animate/main/Animate.gif">
 
@@ -20,22 +20,25 @@ Tested for DearPyGui 0.6x
 **Setup:**
 
 ```python
-from dearpygui.core import *
-from dearpygui.simple import *
+import dearpygui.dearpygui as dpg
+
 import dearpygui_animate as animate
 
-with window("Main"):
-	set_main_window_title("dearpygui_animate    D E M O")
-	set_main_window_size(1280,720)
-  
-with window("Demo", width=200, height=100):
-	add_text("Info", default_value="Hello World!", parent="Demo")
-  
-animate.add("position", "Demo", [622,800], [622, 304], [0,.06,.2,.99], 60)
-animate.add("opacity", "Demo", 0, 1, [.57,.06,.61,.86], 60)
+dpg.create_context()
+dpg.create_viewport(title="dearpygui_animate    D E M O", width=1280, height=720)
 
-set_render_callback(animate.run)
-start_dearpygui(primary_window="Main")
+with dpg.window(label="Demo", tag="Demo", width=200, height=100):
+    dpg.add_text("Hello World!")
+
+animate.add("position", "Demo", [622, 800], [622, 304], [0, .06, .2, .99], 60)
+animate.add("opacity", "Demo", 0, 1, [.57, .06, .61, .86], 60)
+
+dpg.setup_dearpygui()
+dpg.show_viewport()
+while dpg.is_dearpygui_running():
+    animate.run()
+    dpg.render_dearpygui_frame()
+dpg.destroy_context()
 
 ``` 
 


### PR DESCRIPTION
## Changes
- All updated and working with the new latest version of DearPyGui 1.8.0
- Added function `dpg_get_alpha_style` to replace `set_item_style_var(item[0], mvGuiStyleVar_Alpha, [item[1])`
- Updated demo: the theme from the old DPG version is set, removed `add_value("running_animations", "0")`, slightly resized some windows
- Updated example in README
## Bugs
If there is a theme that is attached not only to a changeable/animated object, then other objects will change their values.
To reproduce:
```python
import dearpygui.dearpygui as dpg

import dearpygui_animate as animate

dpg.create_context()
dpg.create_viewport()

with dpg.theme() as button_theme:
    with dpg.theme_component(dpg.mvButton):
        dpg.add_theme_color(dpg.mvThemeCol_Text, (0, 255, 0, 255), category=dpg.mvThemeCat_Core)

with dpg.window():
    btn1 = dpg.add_button(label="Test 1")
    btn2 = dpg.add_button(label="Test 2")

    dpg.bind_item_theme(btn1, button_theme)
    dpg.bind_item_theme(btn2, button_theme)

animate.add("opacity", btn1, 0, 1, [.57, .06, .61, .86], 60, loop="ping-pong")

dpg.setup_dearpygui()
dpg.show_viewport()
while dpg.is_dearpygui_running():
    animate.run()
    dpg.render_dearpygui_frame()
dpg.destroy_context()
```
![0](https://user-images.githubusercontent.com/46572469/216398135-8d8ab4a8-2d07-4cb7-9b6c-a0766fe8f52b.gif)

#### The workaround is to wrap each future animated object into a group:
```python
import dearpygui.dearpygui as dpg

import dearpygui_animate as animate

dpg.create_context()
dpg.create_viewport()

with dpg.theme() as button_theme:
    with dpg.theme_component(dpg.mvButton):
        dpg.add_theme_color(dpg.mvThemeCol_Text, (0, 255, 0, 255), category=dpg.mvThemeCat_Core)

with dpg.window():
    with dpg.group() as btn1_group:
        btn1 = dpg.add_button(label="Test 1")
    btn2 = dpg.add_button(label="Test 2")

    dpg.bind_item_theme(btn1, button_theme)
    dpg.bind_item_theme(btn2, button_theme)

animate.add("opacity", btn1_group, 0, 1, [.57, .06, .61, .86], 60, loop="ping-pong")

dpg.setup_dearpygui()
dpg.show_viewport()
while dpg.is_dearpygui_running():
    animate.run()
    dpg.render_dearpygui_frame()
dpg.destroy_context()
```
![0](https://user-images.githubusercontent.com/46572469/216398380-faae36b5-6cbc-455f-a0f8-0890db0d8347.gif)


### Unfortunately for `dpg.window()` you need to create a new theme
